### PR TITLE
feat: i18n language detection and rerouting middleware

### DIFF
--- a/app/[lng]/_components/NavBar/NavBar.tsx
+++ b/app/[lng]/_components/NavBar/NavBar.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import Filter from "../Filter";
 import Link from "next/link";
 
-const NavBar = () => {
+const NavBar = ({ lng }: { lng: string }) => {
   // md menu
   const [menuIsOpen, setMenuIsOpen] = useState(false);
 

--- a/app/[lng]/_components/NavBar/NavBar.tsx
+++ b/app/[lng]/_components/NavBar/NavBar.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import Filter from "../Filter";
 import Link from "next/link";
 
+// eslint-disable-next-line
 const NavBar = ({ lng }: { lng: string }) => {
   // md menu
   const [menuIsOpen, setMenuIsOpen] = useState(false);

--- a/app/[lng]/layout.tsx
+++ b/app/[lng]/layout.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from "next";
+
 import localFont from "next/font/local";
 import "./globals.css";
+
 import NavBar from "./_components/NavBar";
+
+import { dir } from "i18next";
+import { languages } from "../i18n/settings";
 
 const notoSans = localFont({
   src: "./_fonts/NotoSans-Regular.ttf",
@@ -13,15 +18,22 @@ export const metadata: Metadata = {
   title: "Omamori Finder",
 };
 
-export default function RootLayout({
+export async function generateStaticParams() {
+  return languages.map((lng) => ({ lng }));
+}
+
+export default async function RootLayout({
   children,
-}: Readonly<{
+  params,
+}: {
   children: React.ReactNode;
-}>) {
+  params: Promise<{ lng: string }>;
+}) {
+  const { lng } = await params;
   return (
-    <html lang="en">
+    <html lang={lng} dir={dir(lng)}>
       <body className={`${notoSans.variable} antialiased`}>
-        <NavBar />
+        <NavBar lng={lng} />
         {children}
       </body>
     </html>

--- a/app/[lng]/layout.tsx
+++ b/app/[lng]/layout.tsx
@@ -18,6 +18,7 @@ export const metadata: Metadata = {
   title: "Omamori Finder",
 };
 
+// Pre-render language paths during build
 export async function generateStaticParams() {
   return languages.map((lng) => ({ lng }));
 }

--- a/app/[lng]/page.tsx
+++ b/app/[lng]/page.tsx
@@ -1,7 +1,7 @@
 import Map from "./_components/Map";
 import OmamoriFeedContainer from "./_components/OmamoriFeedContainer";
 
-export default function Home() {
+export default async function Home() {
   return (
     <div>
       <Map />

--- a/app/i18n/settings.ts
+++ b/app/i18n/settings.ts
@@ -1,0 +1,18 @@
+export const fallbackLng = "en";
+export const languages = [fallbackLng, "jp"];
+export const defaultNS = "translation";
+export const cookieName = "i18next";
+
+export function getOptions(
+  lng = fallbackLng,
+  ns: string | string[] = defaultNS
+) {
+  return {
+    supportedLngs: languages,
+    fallbackLng,
+    lng,
+    fallbackNS: defaultNS,
+    defaultNS,
+    ns,
+  };
+}

--- a/app/i18n/settings.ts
+++ b/app/i18n/settings.ts
@@ -1,18 +1,18 @@
 export const fallbackLng = "en";
 export const languages = [fallbackLng, "jp"];
-export const defaultNS = "translation";
+export const defaultNamespace = "translation";
 export const cookieName = "i18next";
 
 export function getOptions(
   lng = fallbackLng,
-  ns: string | string[] = defaultNS
+  namespaces: string | string[] = defaultNamespace
 ) {
   return {
     supportedLngs: languages,
     fallbackLng,
     lng,
-    fallbackNS: defaultNS,
-    defaultNS,
-    ns,
+    fallbackNS: defaultNamespace,
+    defaultNamespace,
+    namespaces,
   };
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,27 +5,36 @@ import { fallbackLng, languages, cookieName } from "./app/i18n/settings";
 acceptLanguage.languages(languages);
 
 export const config = {
-  // matcher: '/:lng*'
   matcher: [
     "/((?!api|_next/static|_next/image|assets|favicon.ico|sw.js|site.webmanifest).*)",
   ],
 };
 
 export function middleware(req: NextRequest) {
-  if (
-    req.nextUrl.pathname.indexOf("icon") > -1 ||
-    req.nextUrl.pathname.indexOf("chrome") > -1
-  )
-    return NextResponse.next();
+  // Exclude paths with icon/chrome
+  // Checks if substring includes icon/chrome, for eg if checking for icon it will return positive if found and -1 if not found
+  const isIconPath = req.nextUrl.pathname.indexOf("icon") > -1
+  const isChromePath = req.nextUrl.pathname.indexOf("chrome") > -1
+  if (isIconPath || isChromePath) {
+    return NextResponse.next()
+  }
+
   let lng: string | undefined | null;
 
   // Check and use cookies if available
-  if (req.cookies.has(cookieName))
-    lng = acceptLanguage.get(req.cookies.get(cookieName)?.value);
-  if (!lng) lng = acceptLanguage.get(req.headers.get("Accept-Language"));
-  if (!lng) lng = fallbackLng;
+  if (req.cookies.has(cookieName)) {
+    lng = acceptLanguage.get(req.cookies.get(cookieName)?.value)
+  }
+  // No cookie = fall back to header
+  if (!lng) {
+    lng = acceptLanguage.get(req.headers.get("Accept-Language"))
+  }
+  // No cookie and no header
+  if (!lng) {
+    lng = fallbackLng
+  }
 
-  // Redirect if lng in path is not supported
+  // Redirect if language in path is not supported
   if (
     !languages.some((loc) => req.nextUrl.pathname.startsWith(`/${loc}`)) &&
     !req.nextUrl.pathname.startsWith("/_next")
@@ -35,15 +44,20 @@ export function middleware(req: NextRequest) {
     );
   }
 
-  if (req.headers.has("referer")) {
-    const refererUrl = new URL(req.headers.get("referer") || "");
+  // Detect language from referer url (url of page the user came from before arriving on the current page)
+  const hasRefererHeader = req.headers.has("referer")
+  if (hasRefererHeader) {
+    const refererUrl = new URL(req.headers.get("referer") || "")
     const lngInReferer = languages.find((l) =>
       refererUrl.pathname.startsWith(`/${l}`)
     );
-    const response = NextResponse.next();
-    if (lngInReferer) response.cookies.set(cookieName, lngInReferer);
-    return response;
+    const response = NextResponse.next()
+    // Store language in cookie
+    if (lngInReferer) {
+      response.cookies.set(cookieName, lngInReferer)
+    }
+    return response
   }
 
-  return NextResponse.next();
+  return NextResponse.next()
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,49 @@
+import { NextResponse, NextRequest } from "next/server";
+import acceptLanguage from "accept-language";
+import { fallbackLng, languages, cookieName } from "./app/i18n/settings";
+
+acceptLanguage.languages(languages);
+
+export const config = {
+  // matcher: '/:lng*'
+  matcher: [
+    "/((?!api|_next/static|_next/image|assets|favicon.ico|sw.js|site.webmanifest).*)",
+  ],
+};
+
+export function middleware(req: NextRequest) {
+  if (
+    req.nextUrl.pathname.indexOf("icon") > -1 ||
+    req.nextUrl.pathname.indexOf("chrome") > -1
+  )
+    return NextResponse.next();
+  let lng: string | undefined | null;
+
+  // Check and use cookies if available
+  if (req.cookies.has(cookieName))
+    lng = acceptLanguage.get(req.cookies.get(cookieName)?.value);
+  if (!lng) lng = acceptLanguage.get(req.headers.get("Accept-Language"));
+  if (!lng) lng = fallbackLng;
+
+  // Redirect if lng in path is not supported
+  if (
+    !languages.some((loc) => req.nextUrl.pathname.startsWith(`/${loc}`)) &&
+    !req.nextUrl.pathname.startsWith("/_next")
+  ) {
+    return NextResponse.redirect(
+      new URL(`/${lng}${req.nextUrl.pathname}${req.nextUrl.search}`, req.url)
+    );
+  }
+
+  if (req.headers.has("referer")) {
+    const refererUrl = new URL(req.headers.get("referer") || "");
+    const lngInReferer = languages.find((l) =>
+      refererUrl.pathname.startsWith(`/${l}`)
+    );
+    const response = NextResponse.next();
+    if (lngInReferer) response.cookies.set(cookieName, lngInReferer);
+    return response;
+  }
+
+  return NextResponse.next();
+}


### PR DESCRIPTION
# Description

Create middleware and adjust root layout to allow for language detection and rerouting based on the user's preferred language (cookies).

_!There is this weird bug_ where if I manually change the language in the url, eg `/about/en` -> `/about/jp`, and then I click on the about button again, it toggles back and forth between /en and /jp. I honestly don't know why this is happening but I'll look at it once I get other things coded in the next PR. It's not a breaking change so I suggest we leave this for now.

# Closes issue(s)

Resolves #57 

# How to test
We can access the website and it should route you to either /en or /jp. 
We can test this fully once I implement a language picker in the navbar + have actual translations done. This will be in the next PR.

# Changes include

1. New middleware created.
2. The root layout, page and navbar component tweaked (Note that there are two linting warnings that `[lng]` is not used, this will be remedied in the next PR. We need to pass lng through the Navbar for a part of the language detection to work.)

# Checklist

- [x] I have tested this code
- [ ] I have updated the README